### PR TITLE
Allow fn property to be an array of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ The route for which the middleware function applies.
 
 **fn**
 
-Type: `Function`
+Type: `Function` or `Array`
 
-The middleware functions. Usually loaded from a separate file using the `require()` syntax
+The middleware function or an array of functions. Usually loaded from a separate file using the `require()` syntax
 
 Example middleware obj:
 ```

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function applyMiddleware(app, config) {
     ensureArray(config.middleware).forEach(item => {
         if (item.fn) {
              const route = item.route || '/';
-            app.use(route, item.fn);
+            app.use(route, ...item.fn);
         }
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/plugin-express",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "A Skeletor plugin to run a local Express server.",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
This matches the Express docs, which allows for an array of callback middleware functions: https://expressjs.com/en/4x/api.html#app.use