### PR TITLE
Made entryPoints config argument optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,9 @@ async function startServer(config, logger) {
     const app = express();
     const port = config.port || 0;
 
-    config.entryPoints.forEach(entry => {
-        const urlPath = entry.route || '/';
-        app.use(urlPath, express.static(path.normalize(`${config.currentDirectory}/${entry.entry}`)));
-    });
+    if (config.entryPoints && Array.isArray(config.entryPoints) && config.entryPoints.length > 0) {
+        applyEntryPoints(app, config.currentDirectory, config.entryPoints);
+    }
 
     if (config.middleware) {
         applyMiddleware(app, config);
@@ -51,6 +50,13 @@ async function startServer(config, logger) {
         const listenerPort = listener.address().port;
         logger.info(`Started server on port ${listenerPort}`);
         opn(`http://localhost:${listenerPort}`);
+    });
+}
+
+function applyEntryPoints(app, currentDirectory, entryPoints = []) {
+    entryPoints.forEach(entry => {
+        const urlPath = entry.route || '/';
+        app.use(urlPath, express.static(path.normalize(`${currentDirectory}/${entry.entry}`)));
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ async function startServer(config, logger) {
     const app = express();
     const port = config.port || 0;
 
-    if (config.entryPoints && Array.isArray(config.entryPoints) && config.entryPoints.length > 0) {
+    if (config.currentDirectory && config.entryPoints && Array.isArray(config.entryPoints) && config.entryPoints.length > 0) {
         applyEntryPoints(app, config.currentDirectory, config.entryPoints);
     }
 
@@ -61,16 +61,14 @@ function applyEntryPoints(app, currentDirectory, entryPoints = []) {
 }
 
 async function run(config, {logger}) {
-    if (config.currentDirectory && config.entryPoints && config.entryPoints.length) {
-        try {
-            await startServer(config, logger);
-            return Promise.resolve({
-                status: 'running'
-            });
-        } catch(error) {
-            return fail(error, logger);
-        }
-    } 
+    try {
+        await startServer(config, logger);
+        return Promise.resolve({
+            status: 'running'
+        });
+    } catch(error) {
+        return fail(error, logger);
+    }
         
     const message = `Error with config. Directory: ${config.currentDirectory}, Entry points: ${config.entryPoints}`;
     return fail(new Error(message), logger);   

--- a/index.test.js
+++ b/index.test.js
@@ -28,28 +28,6 @@ describe('local server plugin', () => {
         logInfoSpy.mockReset();
     });
 
-    it('should error when no entry points specified', async () => {
-        const expectedError = {
-            status: 'error',
-            error: new Error('Error with config. Directory: testDir, Entry points: undefined')
-        };
-        const config = {
-            currentDirectory: 'testDir'
-        };
-        await expect(skeletorLocalServer().run(config, options)).rejects.toEqual(expectedError);
-    });
-
-    it('should error when no current directory specified', async () => {
-        const expectedError = {
-            status: 'error',
-            error: new Error('Error with config. Directory: undefined, Entry points: testDir')
-        };
-        const config = {
-            entryPoints: ['testDir']
-        };
-        await expect(skeletorLocalServer().run(config, options)).rejects.toEqual(expectedError);
-    });
-
     it('should error when listen fails', async () => {
         const expectedError = {
             status: 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/plugin-express",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -9,7 +9,7 @@
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "7.0.0"
             }
         },
         "@babel/core": {
@@ -17,20 +17,20 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
             "integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.4.0",
-                "@babel/helpers": "^7.4.0",
-                "@babel/parser": "^7.4.0",
-                "@babel/template": "^7.4.0",
-                "@babel/traverse": "^7.4.0",
-                "@babel/types": "^7.4.0",
-                "convert-source-map": "^1.1.0",
-                "debug": "^4.1.0",
-                "json5": "^2.1.0",
-                "lodash": "^4.17.11",
-                "resolve": "^1.3.2",
-                "semver": "^5.4.1",
-                "source-map": "^0.5.0"
+                "@babel/code-frame": "7.0.0",
+                "@babel/generator": "7.4.0",
+                "@babel/helpers": "7.4.2",
+                "@babel/parser": "7.4.2",
+                "@babel/template": "7.4.0",
+                "@babel/traverse": "7.4.0",
+                "@babel/types": "7.4.0",
+                "convert-source-map": "1.6.0",
+                "debug": "4.1.1",
+                "json5": "2.1.0",
+                "lodash": "4.17.11",
+                "resolve": "1.10.0",
+                "semver": "5.6.0",
+                "source-map": "0.5.7"
             },
             "dependencies": {
                 "debug": {
@@ -38,7 +38,7 @@
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
                     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -58,11 +58,11 @@
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
             "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
             "requires": {
-                "@babel/types": "^7.4.0",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.11",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "@babel/types": "7.4.0",
+                "jsesc": "2.5.2",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
             },
             "dependencies": {
                 "source-map": {
@@ -77,9 +77,9 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
             "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "requires": {
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/template": "7.4.0",
+                "@babel/types": "7.4.0"
             }
         },
         "@babel/helper-get-function-arity": {
@@ -87,7 +87,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
             "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.4.0"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -100,7 +100,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
             "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
             "requires": {
-                "@babel/types": "^7.4.0"
+                "@babel/types": "7.4.0"
             }
         },
         "@babel/helpers": {
@@ -108,9 +108,9 @@
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
             "integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
             "requires": {
-                "@babel/template": "^7.4.0",
-                "@babel/traverse": "^7.4.0",
-                "@babel/types": "^7.4.0"
+                "@babel/template": "7.4.0",
+                "@babel/traverse": "7.4.0",
+                "@babel/types": "7.4.0"
             }
         },
         "@babel/highlight": {
@@ -118,9 +118,9 @@
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^4.0.0"
+                "chalk": "2.4.2",
+                "esutils": "2.0.2",
+                "js-tokens": "4.0.0"
             },
             "dependencies": {
                 "js-tokens": {
@@ -140,7 +140,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
             "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/template": {
@@ -148,9 +148,9 @@
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
             "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.4.0",
-                "@babel/types": "^7.4.0"
+                "@babel/code-frame": "7.0.0",
+                "@babel/parser": "7.4.2",
+                "@babel/types": "7.4.0"
             }
         },
         "@babel/traverse": {
@@ -158,15 +158,15 @@
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
             "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.4.0",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.4.0",
-                "@babel/parser": "^7.4.0",
-                "@babel/types": "^7.4.0",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.11"
+                "@babel/code-frame": "7.0.0",
+                "@babel/generator": "7.4.0",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.4.0",
+                "@babel/parser": "7.4.2",
+                "@babel/types": "7.4.0",
+                "debug": "4.1.1",
+                "globals": "11.11.0",
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "debug": {
@@ -174,7 +174,7 @@
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
                     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -189,9 +189,9 @@
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
             "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
             "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.11",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.2",
+                "lodash": "4.17.11",
+                "to-fast-properties": "2.0.0"
             }
         },
         "@cnakazawa/watch": {
@@ -199,8 +199,8 @@
             "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
             "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
             "requires": {
-                "exec-sh": "^0.3.2",
-                "minimist": "^1.2.0"
+                "exec-sh": "0.3.2",
+                "minimist": "1.2.0"
             },
             "dependencies": {
                 "minimist": {
@@ -215,10 +215,10 @@
             "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.3.0.tgz",
             "integrity": "sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==",
             "requires": {
-                "@jest/source-map": "^24.3.0",
-                "@types/node": "*",
-                "chalk": "^2.0.1",
-                "slash": "^2.0.0"
+                "@jest/source-map": "24.3.0",
+                "@types/node": "11.11.5",
+                "chalk": "2.4.2",
+                "slash": "2.0.0"
             }
         },
         "@jest/core": {
@@ -226,33 +226,33 @@
             "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.5.0.tgz",
             "integrity": "sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==",
             "requires": {
-                "@jest/console": "^24.3.0",
-                "@jest/reporters": "^24.5.0",
-                "@jest/test-result": "^24.5.0",
-                "@jest/transform": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-changed-files": "^24.5.0",
-                "jest-config": "^24.5.0",
-                "jest-haste-map": "^24.5.0",
-                "jest-message-util": "^24.5.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve-dependencies": "^24.5.0",
-                "jest-runner": "^24.5.0",
-                "jest-runtime": "^24.5.0",
-                "jest-snapshot": "^24.5.0",
-                "jest-util": "^24.5.0",
-                "jest-validate": "^24.5.0",
-                "jest-watcher": "^24.5.0",
-                "micromatch": "^3.1.10",
-                "p-each-series": "^1.0.0",
-                "pirates": "^4.0.1",
-                "realpath-native": "^1.1.0",
-                "rimraf": "^2.5.4",
-                "strip-ansi": "^5.0.0"
+                "@jest/console": "24.3.0",
+                "@jest/reporters": "24.5.0",
+                "@jest/test-result": "24.5.0",
+                "@jest/transform": "24.5.0",
+                "@jest/types": "24.5.0",
+                "ansi-escapes": "3.2.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "graceful-fs": "4.1.15",
+                "jest-changed-files": "24.5.0",
+                "jest-config": "24.5.0",
+                "jest-haste-map": "24.5.0",
+                "jest-message-util": "24.5.0",
+                "jest-regex-util": "24.3.0",
+                "jest-resolve-dependencies": "24.5.0",
+                "jest-runner": "24.5.0",
+                "jest-runtime": "24.5.0",
+                "jest-snapshot": "24.5.0",
+                "jest-util": "24.5.0",
+                "jest-validate": "24.5.0",
+                "jest-watcher": "24.5.0",
+                "micromatch": "3.1.10",
+                "p-each-series": "1.0.0",
+                "pirates": "4.0.1",
+                "realpath-native": "1.1.0",
+                "rimraf": "2.6.3",
+                "strip-ansi": "5.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -265,7 +265,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "requires": {
-                        "ansi-regex": "^4.1.0"
+                        "ansi-regex": "4.1.0"
                     }
                 }
             }
@@ -275,11 +275,11 @@
             "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.5.0.tgz",
             "integrity": "sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==",
             "requires": {
-                "@jest/fake-timers": "^24.5.0",
-                "@jest/transform": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "@types/node": "*",
-                "jest-mock": "^24.5.0"
+                "@jest/fake-timers": "24.5.0",
+                "@jest/transform": "24.5.0",
+                "@jest/types": "24.5.0",
+                "@types/node": "11.11.5",
+                "jest-mock": "24.5.0"
             }
         },
         "@jest/fake-timers": {
@@ -287,10 +287,10 @@
             "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.5.0.tgz",
             "integrity": "sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==",
             "requires": {
-                "@jest/types": "^24.5.0",
-                "@types/node": "*",
-                "jest-message-util": "^24.5.0",
-                "jest-mock": "^24.5.0"
+                "@jest/types": "24.5.0",
+                "@types/node": "11.11.5",
+                "jest-message-util": "24.5.0",
+                "jest-mock": "24.5.0"
             }
         },
         "@jest/reporters": {
@@ -298,26 +298,26 @@
             "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.5.0.tgz",
             "integrity": "sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==",
             "requires": {
-                "@jest/environment": "^24.5.0",
-                "@jest/test-result": "^24.5.0",
-                "@jest/transform": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "glob": "^7.1.2",
-                "istanbul-api": "^2.1.1",
-                "istanbul-lib-coverage": "^2.0.2",
-                "istanbul-lib-instrument": "^3.0.1",
-                "istanbul-lib-source-maps": "^3.0.1",
-                "jest-haste-map": "^24.5.0",
-                "jest-resolve": "^24.5.0",
-                "jest-runtime": "^24.5.0",
-                "jest-util": "^24.5.0",
-                "jest-worker": "^24.4.0",
-                "node-notifier": "^5.2.1",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.0",
-                "string-length": "^2.0.0"
+                "@jest/environment": "24.5.0",
+                "@jest/test-result": "24.5.0",
+                "@jest/transform": "24.5.0",
+                "@jest/types": "24.5.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "glob": "7.1.3",
+                "istanbul-api": "2.1.1",
+                "istanbul-lib-coverage": "2.0.3",
+                "istanbul-lib-instrument": "3.1.0",
+                "istanbul-lib-source-maps": "3.0.2",
+                "jest-haste-map": "24.5.0",
+                "jest-resolve": "24.5.0",
+                "jest-runtime": "24.5.0",
+                "jest-util": "24.5.0",
+                "jest-worker": "24.4.0",
+                "node-notifier": "5.4.0",
+                "slash": "2.0.0",
+                "source-map": "0.6.1",
+                "string-length": "2.0.0"
             }
         },
         "@jest/source-map": {
@@ -325,9 +325,9 @@
             "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
             "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
             "requires": {
-                "callsites": "^3.0.0",
-                "graceful-fs": "^4.1.15",
-                "source-map": "^0.6.0"
+                "callsites": "3.0.0",
+                "graceful-fs": "4.1.15",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "callsites": {
@@ -342,9 +342,9 @@
             "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.5.0.tgz",
             "integrity": "sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==",
             "requires": {
-                "@jest/console": "^24.3.0",
-                "@jest/types": "^24.5.0",
-                "@types/istanbul-lib-coverage": "^1.1.0"
+                "@jest/console": "24.3.0",
+                "@jest/types": "24.5.0",
+                "@types/istanbul-lib-coverage": "1.1.0"
             }
         },
         "@jest/transform": {
@@ -352,20 +352,20 @@
             "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.5.0.tgz",
             "integrity": "sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==",
             "requires": {
-                "@babel/core": "^7.1.0",
-                "@jest/types": "^24.5.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "chalk": "^2.0.1",
-                "convert-source-map": "^1.4.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.1.15",
-                "jest-haste-map": "^24.5.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-util": "^24.5.0",
-                "micromatch": "^3.1.10",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.1",
+                "@babel/core": "7.4.0",
+                "@jest/types": "24.5.0",
+                "babel-plugin-istanbul": "5.1.1",
+                "chalk": "2.4.2",
+                "convert-source-map": "1.6.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "graceful-fs": "4.1.15",
+                "jest-haste-map": "24.5.0",
+                "jest-regex-util": "24.3.0",
+                "jest-util": "24.5.0",
+                "micromatch": "3.1.10",
+                "realpath-native": "1.1.0",
+                "slash": "2.0.0",
+                "source-map": "0.6.1",
                 "write-file-atomic": "2.4.1"
             }
         },
@@ -374,8 +374,8 @@
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.5.0.tgz",
             "integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
             "requires": {
-                "@types/istanbul-lib-coverage": "^1.1.0",
-                "@types/yargs": "^12.0.9"
+                "@types/istanbul-lib-coverage": "1.1.0",
+                "@types/yargs": "12.0.10"
             }
         },
         "@types/babel__core": {
@@ -383,11 +383,11 @@
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
             "integrity": "sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==",
             "requires": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
+                "@babel/parser": "7.4.2",
+                "@babel/types": "7.4.0",
+                "@types/babel__generator": "7.0.2",
+                "@types/babel__template": "7.0.2",
+                "@types/babel__traverse": "7.0.6"
             }
         },
         "@types/babel__generator": {
@@ -395,7 +395,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
             "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.4.0"
             }
         },
         "@types/babel__template": {
@@ -403,8 +403,8 @@
             "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
             "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
             "requires": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/parser": "7.4.2",
+                "@babel/types": "7.4.0"
             }
         },
         "@types/babel__traverse": {
@@ -412,7 +412,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
             "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
             "requires": {
-                "@babel/types": "^7.3.0"
+                "@babel/types": "7.4.0"
             }
         },
         "@types/istanbul-lib-coverage": {
@@ -445,7 +445,7 @@
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "requires": {
-                "mime-types": "~2.1.18",
+                "mime-types": "2.1.22",
                 "negotiator": "0.6.1"
             }
         },
@@ -459,8 +459,8 @@
             "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
             "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
             "requires": {
-                "acorn": "^6.0.1",
-                "acorn-walk": "^6.0.1"
+                "acorn": "6.1.1",
+                "acorn-walk": "6.1.1"
             },
             "dependencies": {
                 "acorn": {
@@ -476,7 +476,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "^3.0.4"
+                "acorn": "3.3.0"
             },
             "dependencies": {
                 "acorn": {
@@ -498,10 +498,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ajv-keywords": {
@@ -531,8 +531,8 @@
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "requires": {
-                "micromatch": "^3.1.4",
-                "normalize-path": "^2.1.1"
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
             }
         },
         "append-transform": {
@@ -540,7 +540,7 @@
             "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
             "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
             "requires": {
-                "default-require-extensions": "^2.0.0"
+                "default-require-extensions": "2.0.0"
             }
         },
         "argparse": {
@@ -548,7 +548,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -591,7 +591,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
-                "safer-buffer": "~2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "assert-plus": {
@@ -645,9 +645,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -656,11 +656,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -669,7 +669,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 }
             }
@@ -679,13 +679,13 @@
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
             "integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
             "requires": {
-                "@jest/transform": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "@types/babel__core": "^7.1.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "babel-preset-jest": "^24.3.0",
-                "chalk": "^2.4.2",
-                "slash": "^2.0.0"
+                "@jest/transform": "24.5.0",
+                "@jest/types": "24.5.0",
+                "@types/babel__core": "7.1.0",
+                "babel-plugin-istanbul": "5.1.1",
+                "babel-preset-jest": "24.3.0",
+                "chalk": "2.4.2",
+                "slash": "2.0.0"
             }
         },
         "babel-plugin-istanbul": {
@@ -693,9 +693,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
             "integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
             "requires": {
-                "find-up": "^3.0.0",
-                "istanbul-lib-instrument": "^3.0.0",
-                "test-exclude": "^5.0.0"
+                "find-up": "3.0.0",
+                "istanbul-lib-instrument": "3.1.0",
+                "test-exclude": "5.1.0"
             }
         },
         "babel-plugin-jest-hoist": {
@@ -703,7 +703,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
             "integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
             "requires": {
-                "@types/babel__traverse": "^7.0.6"
+                "@types/babel__traverse": "7.0.6"
             }
         },
         "babel-preset-jest": {
@@ -711,8 +711,8 @@
             "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
             "integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
             "requires": {
-                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-                "babel-plugin-jest-hoist": "^24.3.0"
+                "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+                "babel-plugin-jest-hoist": "24.3.0"
             }
         },
         "balanced-match": {
@@ -725,13 +725,13 @@
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -739,7 +739,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -747,7 +747,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -755,7 +755,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -763,9 +763,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -775,7 +775,7 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "body-parser": {
@@ -784,15 +784,15 @@
             "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "~1.0.4",
+                "content-type": "1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "http-errors": "~1.6.3",
+                "depd": "1.1.2",
+                "http-errors": "1.6.3",
                 "iconv-lite": "0.4.23",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.3.0",
                 "qs": "6.5.2",
                 "raw-body": "2.3.3",
-                "type-is": "~1.6.16"
+                "type-is": "1.6.16"
             }
         },
         "brace-expansion": {
@@ -800,7 +800,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -809,16 +809,16 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.3",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -826,7 +826,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -856,7 +856,7 @@
             "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
             "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
             "requires": {
-                "node-int64": "^0.4.0"
+                "node-int64": "0.4.0"
             }
         },
         "buffer-from": {
@@ -874,15 +874,15 @@
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
             }
         },
         "caller-path": {
@@ -891,7 +891,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "^0.2.0"
+                "callsites": "0.2.0"
             }
         },
         "callsites": {
@@ -910,7 +910,7 @@
             "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
             "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
             "requires": {
-                "rsvp": "^4.8.4"
+                "rsvp": "4.8.4"
             }
         },
         "caseless": {
@@ -923,9 +923,9 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -933,7 +933,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.3"
                     }
                 },
                 "supports-color": {
@@ -941,7 +941,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -968,10 +968,10 @@
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -979,7 +979,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -990,7 +990,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
             }
         },
         "cli-width": {
@@ -1004,9 +1004,9 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
             }
         },
         "co": {
@@ -1024,8 +1024,8 @@
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color-convert": {
@@ -1046,7 +1046,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -1076,10 +1076,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.1.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             }
         },
         "content-disposition": {
@@ -1097,7 +1097,7 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "requires": {
-                "safe-buffer": "~5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "cookie": {
@@ -1126,9 +1126,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "lru-cache": "4.1.5",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
             }
         },
         "cssom": {
@@ -1141,7 +1141,7 @@
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
             "integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "0.3.6"
             }
         },
         "dashdash": {
@@ -1149,7 +1149,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "data-urls": {
@@ -1157,9 +1157,9 @@
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
             "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
             "requires": {
-                "abab": "^2.0.0",
-                "whatwg-mimetype": "^2.2.0",
-                "whatwg-url": "^7.0.0"
+                "abab": "2.0.0",
+                "whatwg-mimetype": "2.3.0",
+                "whatwg-url": "7.0.0"
             },
             "dependencies": {
                 "whatwg-url": {
@@ -1167,9 +1167,9 @@
                     "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
                     "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
                     "requires": {
-                        "lodash.sortby": "^4.7.0",
-                        "tr46": "^1.0.1",
-                        "webidl-conversions": "^4.0.2"
+                        "lodash.sortby": "4.7.0",
+                        "tr46": "1.0.1",
+                        "webidl-conversions": "4.0.2"
                     }
                 }
             }
@@ -1202,7 +1202,7 @@
             "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
             "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
             "requires": {
-                "strip-bom": "^3.0.0"
+                "strip-bom": "3.0.0"
             }
         },
         "define-properties": {
@@ -1210,7 +1210,7 @@
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "requires": {
-                "object-keys": "^1.0.12"
+                "object-keys": "1.1.0"
             }
         },
         "define-property": {
@@ -1218,8 +1218,8 @@
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -1227,7 +1227,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -1235,7 +1235,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -1243,9 +1243,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -1281,7 +1281,7 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2"
+                "esutils": "2.0.2"
             }
         },
         "domexception": {
@@ -1289,7 +1289,7 @@
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
             "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
             "requires": {
-                "webidl-conversions": "^4.0.2"
+                "webidl-conversions": "4.0.2"
             }
         },
         "ecc-jsbn": {
@@ -1297,8 +1297,8 @@
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "ee-first": {
@@ -1316,7 +1316,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "error-ex": {
@@ -1324,7 +1324,7 @@
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "es-abstract": {
@@ -1332,12 +1332,12 @@
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
             "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
             "requires": {
-                "es-to-primitive": "^1.2.0",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "is-callable": "^1.1.4",
-                "is-regex": "^1.0.4",
-                "object-keys": "^1.0.12"
+                "es-to-primitive": "1.2.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3",
+                "is-callable": "1.1.4",
+                "is-regex": "1.0.4",
+                "object-keys": "1.1.0"
             }
         },
         "es-to-primitive": {
@@ -1345,9 +1345,9 @@
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
             "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
+                "is-callable": "1.1.4",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.2"
             }
         },
         "escape-html": {
@@ -1365,11 +1365,11 @@
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
             "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
             "requires": {
-                "esprima": "^3.1.3",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "esprima": {
@@ -1385,44 +1385,44 @@
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
-                "ajv": "^5.3.0",
-                "babel-code-frame": "^6.22.0",
-                "chalk": "^2.1.0",
-                "concat-stream": "^1.6.0",
-                "cross-spawn": "^5.1.0",
-                "debug": "^3.1.0",
-                "doctrine": "^2.1.0",
-                "eslint-scope": "^3.7.1",
-                "eslint-visitor-keys": "^1.0.0",
-                "espree": "^3.5.4",
-                "esquery": "^1.0.0",
-                "esutils": "^2.0.2",
-                "file-entry-cache": "^2.0.0",
-                "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
-                "globals": "^11.0.1",
-                "ignore": "^3.3.3",
-                "imurmurhash": "^0.1.4",
-                "inquirer": "^3.0.6",
-                "is-resolvable": "^1.0.0",
-                "js-yaml": "^3.9.1",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.3.0",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
-                "pluralize": "^7.0.0",
-                "progress": "^2.0.0",
-                "regexpp": "^1.0.1",
-                "require-uncached": "^1.0.3",
-                "semver": "^5.3.0",
-                "strip-ansi": "^4.0.0",
-                "strip-json-comments": "~2.0.1",
+                "ajv": "5.5.2",
+                "babel-code-frame": "6.26.0",
+                "chalk": "2.4.2",
+                "concat-stream": "1.6.2",
+                "cross-spawn": "5.1.0",
+                "debug": "3.2.6",
+                "doctrine": "2.1.0",
+                "eslint-scope": "3.7.3",
+                "eslint-visitor-keys": "1.0.0",
+                "espree": "3.5.4",
+                "esquery": "1.0.1",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.3",
+                "globals": "11.11.0",
+                "ignore": "3.3.10",
+                "imurmurhash": "0.1.4",
+                "inquirer": "3.3.0",
+                "is-resolvable": "1.1.0",
+                "js-yaml": "3.13.0",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "7.0.0",
+                "progress": "2.0.3",
+                "regexpp": "1.1.0",
+                "require-uncached": "1.0.3",
+                "semver": "5.6.0",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
                 "table": "4.0.2",
-                "text-table": "~0.2.0"
+                "text-table": "0.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -1431,7 +1431,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -1448,8 +1448,8 @@
             "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
             }
         },
         "eslint-visitor-keys": {
@@ -1464,8 +1464,8 @@
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
-                "acorn": "^5.5.0",
-                "acorn-jsx": "^3.0.0"
+                "acorn": "5.7.3",
+                "acorn-jsx": "3.0.1"
             }
         },
         "esprima": {
@@ -1479,7 +1479,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.0.0"
+                "estraverse": "4.2.0"
             }
         },
         "esrecurse": {
@@ -1488,7 +1488,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "4.2.0"
             }
         },
         "estraverse": {
@@ -1516,13 +1516,13 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
             "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
             "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "6.0.5",
+                "get-stream": "4.1.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -1530,11 +1530,11 @@
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "nice-try": "1.0.5",
+                        "path-key": "2.0.1",
+                        "semver": "5.6.0",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
                     }
                 }
             }
@@ -1549,13 +1549,13 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -1563,7 +1563,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -1571,7 +1571,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -1581,12 +1581,12 @@
             "resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
             "integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
             "requires": {
-                "@jest/types": "^24.5.0",
-                "ansi-styles": "^3.2.0",
-                "jest-get-type": "^24.3.0",
-                "jest-matcher-utils": "^24.5.0",
-                "jest-message-util": "^24.5.0",
-                "jest-regex-util": "^24.3.0"
+                "@jest/types": "24.5.0",
+                "ansi-styles": "3.2.1",
+                "jest-get-type": "24.3.0",
+                "jest-matcher-utils": "24.5.0",
+                "jest-message-util": "24.5.0",
+                "jest-regex-util": "24.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1594,7 +1594,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.3"
                     }
                 }
             }
@@ -1604,36 +1604,36 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
             "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
             "requires": {
-                "accepts": "~1.3.5",
+                "accepts": "1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.3",
                 "content-disposition": "0.5.2",
-                "content-type": "~1.0.4",
+                "content-type": "1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
+                "depd": "1.1.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
                 "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.4",
+                "proxy-addr": "2.0.4",
                 "qs": "6.5.2",
-                "range-parser": "~1.2.0",
+                "range-parser": "1.2.0",
                 "safe-buffer": "5.1.2",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "~1.4.0",
-                "type-is": "~1.6.16",
+                "statuses": "1.4.0",
+                "type-is": "1.6.16",
                 "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
+                "vary": "1.1.2"
             }
         },
         "extend": {
@@ -1646,8 +1646,8 @@
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1655,7 +1655,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -1666,9 +1666,9 @@
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
-                "chardet": "^0.4.0",
-                "iconv-lite": "^0.4.17",
-                "tmp": "^0.0.33"
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.23",
+                "tmp": "0.0.33"
             }
         },
         "extglob": {
@@ -1676,14 +1676,14 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -1691,7 +1691,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "extend-shallow": {
@@ -1699,7 +1699,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1707,7 +1707,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -1715,7 +1715,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -1723,9 +1723,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -1756,7 +1756,7 @@
             "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
             "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
             "requires": {
-                "bser": "^2.0.0"
+                "bser": "2.0.0"
             }
         },
         "figures": {
@@ -1765,7 +1765,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.5"
+                "escape-string-regexp": "1.0.5"
             }
         },
         "file-entry-cache": {
@@ -1774,8 +1774,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "^1.2.1",
-                "object-assign": "^4.0.1"
+                "flat-cache": "1.3.4",
+                "object-assign": "4.1.1"
             }
         },
         "fileset": {
@@ -1783,8 +1783,8 @@
             "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
             "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
             "requires": {
-                "glob": "^7.0.3",
-                "minimatch": "^3.0.3"
+                "glob": "7.1.3",
+                "minimatch": "3.0.4"
             }
         },
         "fill-range": {
@@ -1792,10 +1792,10 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1803,7 +1803,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -1814,12 +1814,12 @@
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
-                "statuses": "~1.4.0",
-                "unpipe": "~1.0.0"
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "statuses": "1.4.0",
+                "unpipe": "1.0.0"
             }
         },
         "find-up": {
@@ -1827,7 +1827,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
             "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
             "requires": {
-                "locate-path": "^3.0.0"
+                "locate-path": "3.0.0"
             }
         },
         "flat-cache": {
@@ -1836,10 +1836,10 @@
             "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
             "dev": true,
             "requires": {
-                "circular-json": "^0.3.1",
-                "graceful-fs": "^4.1.2",
-                "rimraf": "~2.6.2",
-                "write": "^0.2.1"
+                "circular-json": "0.3.3",
+                "graceful-fs": "4.1.15",
+                "rimraf": "2.6.3",
+                "write": "0.2.1"
             }
         },
         "for-in": {
@@ -1857,9 +1857,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.7",
+                "mime-types": "2.1.22"
             }
         },
         "forwarded": {
@@ -1872,7 +1872,7 @@
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "fresh": {
@@ -1906,7 +1906,7 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
             "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
             "requires": {
-                "pump": "^3.0.0"
+                "pump": "3.0.0"
             }
         },
         "get-value": {
@@ -1919,7 +1919,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -1927,12 +1927,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "globals": {
@@ -1955,10 +1955,10 @@
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
             "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
             "requires": {
-                "neo-async": "^2.6.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
+                "neo-async": "2.6.0",
+                "optimist": "0.6.1",
+                "source-map": "0.6.1",
+                "uglify-js": "3.5.1"
             }
         },
         "har-schema": {
@@ -1971,8 +1971,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
+                "ajv": "6.10.0",
+                "har-schema": "2.0.0"
             },
             "dependencies": {
                 "ajv": {
@@ -1980,10 +1980,10 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
                     "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.4.1",
+                        "uri-js": "4.2.2"
                     }
                 },
                 "fast-deep-equal": {
@@ -2003,7 +2003,7 @@
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -2012,7 +2012,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -2030,9 +2030,9 @@
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             }
         },
         "has-values": {
@@ -2040,8 +2040,8 @@
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2049,7 +2049,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -2064,7 +2064,7 @@
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "requires": {
-                "whatwg-encoding": "^1.0.1"
+                "whatwg-encoding": "1.0.5"
             }
         },
         "http-errors": {
@@ -2072,10 +2072,10 @@
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
-                "depd": "~1.1.2",
+                "depd": "1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
+                "statuses": "1.4.0"
             }
         },
         "http-signature": {
@@ -2083,9 +2083,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.16.1"
             }
         },
         "iconv-lite": {
@@ -2093,7 +2093,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
             }
         },
         "ignore": {
@@ -2107,8 +2107,8 @@
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
             "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
             "requires": {
-                "pkg-dir": "^3.0.0",
-                "resolve-cwd": "^2.0.0"
+                "pkg-dir": "3.0.0",
+                "resolve-cwd": "2.0.0"
             }
         },
         "imurmurhash": {
@@ -2121,8 +2121,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -2136,20 +2136,20 @@
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.0.4",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
+                "ansi-escapes": "3.2.0",
+                "chalk": "2.4.2",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.11",
                 "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rx-lite": "^4.0.8",
-                "rx-lite-aggregates": "^4.0.8",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
+                "run-async": "2.3.0",
+                "rx-lite": "4.0.8",
+                "rx-lite-aggregates": "4.0.8",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
             }
         },
         "invariant": {
@@ -2157,7 +2157,7 @@
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "invert-kv": {
@@ -2175,7 +2175,7 @@
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2183,7 +2183,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -2208,7 +2208,7 @@
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
             "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
             "requires": {
-                "ci-info": "^2.0.0"
+                "ci-info": "2.0.0"
             }
         },
         "is-data-descriptor": {
@@ -2216,7 +2216,7 @@
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2224,7 +2224,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -2239,9 +2239,9 @@
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2271,7 +2271,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2279,7 +2279,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -2289,7 +2289,7 @@
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "is-promise": {
@@ -2303,7 +2303,7 @@
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "requires": {
-                "has": "^1.0.1"
+                "has": "1.0.3"
             }
         },
         "is-resolvable": {
@@ -2322,7 +2322,7 @@
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "1.0.0"
             }
         },
         "is-typedarray": {
@@ -2365,19 +2365,19 @@
             "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
             "integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
             "requires": {
-                "async": "^2.6.1",
-                "compare-versions": "^3.2.1",
-                "fileset": "^2.0.3",
-                "istanbul-lib-coverage": "^2.0.3",
-                "istanbul-lib-hook": "^2.0.3",
-                "istanbul-lib-instrument": "^3.1.0",
-                "istanbul-lib-report": "^2.0.4",
-                "istanbul-lib-source-maps": "^3.0.2",
-                "istanbul-reports": "^2.1.1",
-                "js-yaml": "^3.12.0",
-                "make-dir": "^1.3.0",
-                "minimatch": "^3.0.4",
-                "once": "^1.4.0"
+                "async": "2.6.2",
+                "compare-versions": "3.4.0",
+                "fileset": "2.0.3",
+                "istanbul-lib-coverage": "2.0.3",
+                "istanbul-lib-hook": "2.0.3",
+                "istanbul-lib-instrument": "3.1.0",
+                "istanbul-lib-report": "2.0.4",
+                "istanbul-lib-source-maps": "3.0.2",
+                "istanbul-reports": "2.1.1",
+                "js-yaml": "3.13.0",
+                "make-dir": "1.3.0",
+                "minimatch": "3.0.4",
+                "once": "1.4.0"
             },
             "dependencies": {
                 "async": {
@@ -2385,7 +2385,7 @@
                     "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
                     "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
                     "requires": {
-                        "lodash": "^4.17.11"
+                        "lodash": "4.17.11"
                     }
                 }
             }
@@ -2400,7 +2400,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
             "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
             "requires": {
-                "append-transform": "^1.0.0"
+                "append-transform": "1.0.0"
             }
         },
         "istanbul-lib-instrument": {
@@ -2408,13 +2408,13 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
             "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
             "requires": {
-                "@babel/generator": "^7.0.0",
-                "@babel/parser": "^7.0.0",
-                "@babel/template": "^7.0.0",
-                "@babel/traverse": "^7.0.0",
-                "@babel/types": "^7.0.0",
-                "istanbul-lib-coverage": "^2.0.3",
-                "semver": "^5.5.0"
+                "@babel/generator": "7.4.0",
+                "@babel/parser": "7.4.2",
+                "@babel/template": "7.4.0",
+                "@babel/traverse": "7.4.0",
+                "@babel/types": "7.4.0",
+                "istanbul-lib-coverage": "2.0.3",
+                "semver": "5.6.0"
             }
         },
         "istanbul-lib-report": {
@@ -2422,9 +2422,9 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
             "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
             "requires": {
-                "istanbul-lib-coverage": "^2.0.3",
-                "make-dir": "^1.3.0",
-                "supports-color": "^6.0.0"
+                "istanbul-lib-coverage": "2.0.3",
+                "make-dir": "1.3.0",
+                "supports-color": "6.1.0"
             },
             "dependencies": {
                 "supports-color": {
@@ -2432,7 +2432,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -2442,11 +2442,11 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
             "integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
             "requires": {
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^2.0.3",
-                "make-dir": "^1.3.0",
-                "rimraf": "^2.6.2",
-                "source-map": "^0.6.1"
+                "debug": "4.1.1",
+                "istanbul-lib-coverage": "2.0.3",
+                "make-dir": "1.3.0",
+                "rimraf": "2.6.3",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "debug": {
@@ -2454,7 +2454,7 @@
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
                     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -2469,7 +2469,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
             "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
             "requires": {
-                "handlebars": "^4.1.0"
+                "handlebars": "4.1.1"
             }
         },
         "jest": {
@@ -2477,8 +2477,8 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-24.5.0.tgz",
             "integrity": "sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==",
             "requires": {
-                "import-local": "^2.0.0",
-                "jest-cli": "^24.5.0"
+                "import-local": "2.0.0",
+                "jest-cli": "24.5.0"
             },
             "dependencies": {
                 "jest-cli": {
@@ -2486,19 +2486,19 @@
                     "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.5.0.tgz",
                     "integrity": "sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==",
                     "requires": {
-                        "@jest/core": "^24.5.0",
-                        "@jest/test-result": "^24.5.0",
-                        "@jest/types": "^24.5.0",
-                        "chalk": "^2.0.1",
-                        "exit": "^0.1.2",
-                        "import-local": "^2.0.0",
-                        "is-ci": "^2.0.0",
-                        "jest-config": "^24.5.0",
-                        "jest-util": "^24.5.0",
-                        "jest-validate": "^24.5.0",
-                        "prompts": "^2.0.1",
-                        "realpath-native": "^1.1.0",
-                        "yargs": "^12.0.2"
+                        "@jest/core": "24.5.0",
+                        "@jest/test-result": "24.5.0",
+                        "@jest/types": "24.5.0",
+                        "chalk": "2.4.2",
+                        "exit": "0.1.2",
+                        "import-local": "2.0.0",
+                        "is-ci": "2.0.0",
+                        "jest-config": "24.5.0",
+                        "jest-util": "24.5.0",
+                        "jest-validate": "24.5.0",
+                        "prompts": "2.0.4",
+                        "realpath-native": "1.1.0",
+                        "yargs": "12.0.5"
                     }
                 }
             }
@@ -2508,9 +2508,9 @@
             "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.5.0.tgz",
             "integrity": "sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==",
             "requires": {
-                "@jest/types": "^24.5.0",
-                "execa": "^1.0.0",
-                "throat": "^4.0.0"
+                "@jest/types": "24.5.0",
+                "execa": "1.0.0",
+                "throat": "4.1.0"
             }
         },
         "jest-config": {
@@ -2518,22 +2518,22 @@
             "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
             "integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
             "requires": {
-                "@babel/core": "^7.1.0",
-                "@jest/types": "^24.5.0",
-                "babel-jest": "^24.5.0",
-                "chalk": "^2.0.1",
-                "glob": "^7.1.1",
-                "jest-environment-jsdom": "^24.5.0",
-                "jest-environment-node": "^24.5.0",
-                "jest-get-type": "^24.3.0",
-                "jest-jasmine2": "^24.5.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.5.0",
-                "jest-util": "^24.5.0",
-                "jest-validate": "^24.5.0",
-                "micromatch": "^3.1.10",
-                "pretty-format": "^24.5.0",
-                "realpath-native": "^1.1.0"
+                "@babel/core": "7.4.0",
+                "@jest/types": "24.5.0",
+                "babel-jest": "24.5.0",
+                "chalk": "2.4.2",
+                "glob": "7.1.3",
+                "jest-environment-jsdom": "24.5.0",
+                "jest-environment-node": "24.5.0",
+                "jest-get-type": "24.3.0",
+                "jest-jasmine2": "24.5.0",
+                "jest-regex-util": "24.3.0",
+                "jest-resolve": "24.5.0",
+                "jest-util": "24.5.0",
+                "jest-validate": "24.5.0",
+                "micromatch": "3.1.10",
+                "pretty-format": "24.5.0",
+                "realpath-native": "1.1.0"
             }
         },
         "jest-diff": {
@@ -2541,10 +2541,10 @@
             "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
             "integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
             "requires": {
-                "chalk": "^2.0.1",
-                "diff-sequences": "^24.3.0",
-                "jest-get-type": "^24.3.0",
-                "pretty-format": "^24.5.0"
+                "chalk": "2.4.2",
+                "diff-sequences": "24.3.0",
+                "jest-get-type": "24.3.0",
+                "pretty-format": "24.5.0"
             }
         },
         "jest-docblock": {
@@ -2552,7 +2552,7 @@
             "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
             "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
             "requires": {
-                "detect-newline": "^2.1.0"
+                "detect-newline": "2.1.0"
             }
         },
         "jest-each": {
@@ -2560,11 +2560,11 @@
             "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
             "integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
             "requires": {
-                "@jest/types": "^24.5.0",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.3.0",
-                "jest-util": "^24.5.0",
-                "pretty-format": "^24.5.0"
+                "@jest/types": "24.5.0",
+                "chalk": "2.4.2",
+                "jest-get-type": "24.3.0",
+                "jest-util": "24.5.0",
+                "pretty-format": "24.5.0"
             }
         },
         "jest-environment-jsdom": {
@@ -2572,12 +2572,12 @@
             "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
             "integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
             "requires": {
-                "@jest/environment": "^24.5.0",
-                "@jest/fake-timers": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "jest-mock": "^24.5.0",
-                "jest-util": "^24.5.0",
-                "jsdom": "^11.5.1"
+                "@jest/environment": "24.5.0",
+                "@jest/fake-timers": "24.5.0",
+                "@jest/types": "24.5.0",
+                "jest-mock": "24.5.0",
+                "jest-util": "24.5.0",
+                "jsdom": "11.12.0"
             }
         },
         "jest-environment-node": {
@@ -2585,11 +2585,11 @@
             "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
             "integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
             "requires": {
-                "@jest/environment": "^24.5.0",
-                "@jest/fake-timers": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "jest-mock": "^24.5.0",
-                "jest-util": "^24.5.0"
+                "@jest/environment": "24.5.0",
+                "@jest/fake-timers": "24.5.0",
+                "@jest/types": "24.5.0",
+                "jest-mock": "24.5.0",
+                "jest-util": "24.5.0"
             }
         },
         "jest-get-type": {
@@ -2602,15 +2602,15 @@
             "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
             "integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
             "requires": {
-                "@jest/types": "^24.5.0",
-                "fb-watchman": "^2.0.0",
-                "graceful-fs": "^4.1.15",
-                "invariant": "^2.2.4",
-                "jest-serializer": "^24.4.0",
-                "jest-util": "^24.5.0",
-                "jest-worker": "^24.4.0",
-                "micromatch": "^3.1.10",
-                "sane": "^4.0.3"
+                "@jest/types": "24.5.0",
+                "fb-watchman": "2.0.0",
+                "graceful-fs": "4.1.15",
+                "invariant": "2.2.4",
+                "jest-serializer": "24.4.0",
+                "jest-util": "24.5.0",
+                "jest-worker": "24.4.0",
+                "micromatch": "3.1.10",
+                "sane": "4.1.0"
             }
         },
         "jest-jasmine2": {
@@ -2618,22 +2618,22 @@
             "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
             "integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^24.5.0",
-                "@jest/test-result": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "chalk": "^2.0.1",
-                "co": "^4.6.0",
-                "expect": "^24.5.0",
-                "is-generator-fn": "^2.0.0",
-                "jest-each": "^24.5.0",
-                "jest-matcher-utils": "^24.5.0",
-                "jest-message-util": "^24.5.0",
-                "jest-runtime": "^24.5.0",
-                "jest-snapshot": "^24.5.0",
-                "jest-util": "^24.5.0",
-                "pretty-format": "^24.5.0",
-                "throat": "^4.0.0"
+                "@babel/traverse": "7.4.0",
+                "@jest/environment": "24.5.0",
+                "@jest/test-result": "24.5.0",
+                "@jest/types": "24.5.0",
+                "chalk": "2.4.2",
+                "co": "4.6.0",
+                "expect": "24.5.0",
+                "is-generator-fn": "2.0.0",
+                "jest-each": "24.5.0",
+                "jest-matcher-utils": "24.5.0",
+                "jest-message-util": "24.5.0",
+                "jest-runtime": "24.5.0",
+                "jest-snapshot": "24.5.0",
+                "jest-util": "24.5.0",
+                "pretty-format": "24.5.0",
+                "throat": "4.1.0"
             }
         },
         "jest-leak-detector": {
@@ -2641,7 +2641,7 @@
             "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.5.0.tgz",
             "integrity": "sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==",
             "requires": {
-                "pretty-format": "^24.5.0"
+                "pretty-format": "24.5.0"
             }
         },
         "jest-matcher-utils": {
@@ -2649,10 +2649,10 @@
             "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
             "integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
             "requires": {
-                "chalk": "^2.0.1",
-                "jest-diff": "^24.5.0",
-                "jest-get-type": "^24.3.0",
-                "pretty-format": "^24.5.0"
+                "chalk": "2.4.2",
+                "jest-diff": "24.5.0",
+                "jest-get-type": "24.3.0",
+                "pretty-format": "24.5.0"
             }
         },
         "jest-message-util": {
@@ -2660,14 +2660,14 @@
             "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
             "integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@jest/test-result": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "@types/stack-utils": "^1.0.1",
-                "chalk": "^2.0.1",
-                "micromatch": "^3.1.10",
-                "slash": "^2.0.0",
-                "stack-utils": "^1.0.1"
+                "@babel/code-frame": "7.0.0",
+                "@jest/test-result": "24.5.0",
+                "@jest/types": "24.5.0",
+                "@types/stack-utils": "1.0.1",
+                "chalk": "2.4.2",
+                "micromatch": "3.1.10",
+                "slash": "2.0.0",
+                "stack-utils": "1.0.2"
             }
         },
         "jest-mock": {
@@ -2675,7 +2675,7 @@
             "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
             "integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
             "requires": {
-                "@jest/types": "^24.5.0"
+                "@jest/types": "24.5.0"
             }
         },
         "jest-pnp-resolver": {
@@ -2693,11 +2693,11 @@
             "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
             "integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
             "requires": {
-                "@jest/types": "^24.5.0",
-                "browser-resolve": "^1.11.3",
-                "chalk": "^2.0.1",
-                "jest-pnp-resolver": "^1.2.1",
-                "realpath-native": "^1.1.0"
+                "@jest/types": "24.5.0",
+                "browser-resolve": "1.11.3",
+                "chalk": "2.4.2",
+                "jest-pnp-resolver": "1.2.1",
+                "realpath-native": "1.1.0"
             }
         },
         "jest-resolve-dependencies": {
@@ -2705,9 +2705,9 @@
             "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.5.0.tgz",
             "integrity": "sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==",
             "requires": {
-                "@jest/types": "^24.5.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-snapshot": "^24.5.0"
+                "@jest/types": "24.5.0",
+                "jest-regex-util": "24.3.0",
+                "jest-snapshot": "24.5.0"
             }
         },
         "jest-runner": {
@@ -2715,25 +2715,25 @@
             "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.5.0.tgz",
             "integrity": "sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==",
             "requires": {
-                "@jest/console": "^24.3.0",
-                "@jest/environment": "^24.5.0",
-                "@jest/test-result": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "chalk": "^2.4.2",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.5.0",
-                "jest-docblock": "^24.3.0",
-                "jest-haste-map": "^24.5.0",
-                "jest-jasmine2": "^24.5.0",
-                "jest-leak-detector": "^24.5.0",
-                "jest-message-util": "^24.5.0",
-                "jest-resolve": "^24.5.0",
-                "jest-runtime": "^24.5.0",
-                "jest-util": "^24.5.0",
-                "jest-worker": "^24.4.0",
-                "source-map-support": "^0.5.6",
-                "throat": "^4.0.0"
+                "@jest/console": "24.3.0",
+                "@jest/environment": "24.5.0",
+                "@jest/test-result": "24.5.0",
+                "@jest/types": "24.5.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "graceful-fs": "4.1.15",
+                "jest-config": "24.5.0",
+                "jest-docblock": "24.3.0",
+                "jest-haste-map": "24.5.0",
+                "jest-jasmine2": "24.5.0",
+                "jest-leak-detector": "24.5.0",
+                "jest-message-util": "24.5.0",
+                "jest-resolve": "24.5.0",
+                "jest-runtime": "24.5.0",
+                "jest-util": "24.5.0",
+                "jest-worker": "24.4.0",
+                "source-map-support": "0.5.11",
+                "throat": "4.1.0"
             }
         },
         "jest-runtime": {
@@ -2741,29 +2741,29 @@
             "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
             "integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
             "requires": {
-                "@jest/console": "^24.3.0",
-                "@jest/environment": "^24.5.0",
-                "@jest/source-map": "^24.3.0",
-                "@jest/transform": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "@types/yargs": "^12.0.2",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.5.0",
-                "jest-haste-map": "^24.5.0",
-                "jest-message-util": "^24.5.0",
-                "jest-mock": "^24.5.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.5.0",
-                "jest-snapshot": "^24.5.0",
-                "jest-util": "^24.5.0",
-                "jest-validate": "^24.5.0",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
-                "strip-bom": "^3.0.0",
-                "yargs": "^12.0.2"
+                "@jest/console": "24.3.0",
+                "@jest/environment": "24.5.0",
+                "@jest/source-map": "24.3.0",
+                "@jest/transform": "24.5.0",
+                "@jest/types": "24.5.0",
+                "@types/yargs": "12.0.10",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "glob": "7.1.3",
+                "graceful-fs": "4.1.15",
+                "jest-config": "24.5.0",
+                "jest-haste-map": "24.5.0",
+                "jest-message-util": "24.5.0",
+                "jest-mock": "24.5.0",
+                "jest-regex-util": "24.3.0",
+                "jest-resolve": "24.5.0",
+                "jest-snapshot": "24.5.0",
+                "jest-util": "24.5.0",
+                "jest-validate": "24.5.0",
+                "realpath-native": "1.1.0",
+                "slash": "2.0.0",
+                "strip-bom": "3.0.0",
+                "yargs": "12.0.5"
             }
         },
         "jest-serializer": {
@@ -2776,18 +2776,18 @@
             "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
             "integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
             "requires": {
-                "@babel/types": "^7.0.0",
-                "@jest/types": "^24.5.0",
-                "chalk": "^2.0.1",
-                "expect": "^24.5.0",
-                "jest-diff": "^24.5.0",
-                "jest-matcher-utils": "^24.5.0",
-                "jest-message-util": "^24.5.0",
-                "jest-resolve": "^24.5.0",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^24.5.0",
-                "semver": "^5.5.0"
+                "@babel/types": "7.4.0",
+                "@jest/types": "24.5.0",
+                "chalk": "2.4.2",
+                "expect": "24.5.0",
+                "jest-diff": "24.5.0",
+                "jest-matcher-utils": "24.5.0",
+                "jest-message-util": "24.5.0",
+                "jest-resolve": "24.5.0",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "pretty-format": "24.5.0",
+                "semver": "5.6.0"
             }
         },
         "jest-util": {
@@ -2795,19 +2795,19 @@
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
             "integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
             "requires": {
-                "@jest/console": "^24.3.0",
-                "@jest/fake-timers": "^24.5.0",
-                "@jest/source-map": "^24.3.0",
-                "@jest/test-result": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "@types/node": "*",
-                "callsites": "^3.0.0",
-                "chalk": "^2.0.1",
-                "graceful-fs": "^4.1.15",
-                "is-ci": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.0"
+                "@jest/console": "24.3.0",
+                "@jest/fake-timers": "24.5.0",
+                "@jest/source-map": "24.3.0",
+                "@jest/test-result": "24.5.0",
+                "@jest/types": "24.5.0",
+                "@types/node": "11.11.5",
+                "callsites": "3.0.0",
+                "chalk": "2.4.2",
+                "graceful-fs": "4.1.15",
+                "is-ci": "2.0.0",
+                "mkdirp": "0.5.1",
+                "slash": "2.0.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "callsites": {
@@ -2822,12 +2822,12 @@
             "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
             "integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
             "requires": {
-                "@jest/types": "^24.5.0",
-                "camelcase": "^5.0.0",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.3.0",
-                "leven": "^2.1.0",
-                "pretty-format": "^24.5.0"
+                "@jest/types": "24.5.0",
+                "camelcase": "5.2.0",
+                "chalk": "2.4.2",
+                "jest-get-type": "24.3.0",
+                "leven": "2.1.0",
+                "pretty-format": "24.5.0"
             }
         },
         "jest-watcher": {
@@ -2835,14 +2835,14 @@
             "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.5.0.tgz",
             "integrity": "sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==",
             "requires": {
-                "@jest/test-result": "^24.5.0",
-                "@jest/types": "^24.5.0",
-                "@types/node": "*",
-                "@types/yargs": "^12.0.9",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "jest-util": "^24.5.0",
-                "string-length": "^2.0.0"
+                "@jest/test-result": "24.5.0",
+                "@jest/types": "24.5.0",
+                "@types/node": "11.11.5",
+                "@types/yargs": "12.0.10",
+                "ansi-escapes": "3.2.0",
+                "chalk": "2.4.2",
+                "jest-util": "24.5.0",
+                "string-length": "2.0.0"
             }
         },
         "jest-worker": {
@@ -2850,9 +2850,9 @@
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
             "integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
             "requires": {
-                "@types/node": "*",
-                "merge-stream": "^1.0.1",
-                "supports-color": "^6.1.0"
+                "@types/node": "11.11.5",
+                "merge-stream": "1.0.1",
+                "supports-color": "6.1.0"
             },
             "dependencies": {
                 "supports-color": {
@@ -2860,7 +2860,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -2875,8 +2875,8 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
             "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.1"
             }
         },
         "jsbn": {
@@ -2889,32 +2889,32 @@
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
             "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
             "requires": {
-                "abab": "^2.0.0",
-                "acorn": "^5.5.3",
-                "acorn-globals": "^4.1.0",
-                "array-equal": "^1.0.0",
-                "cssom": ">= 0.3.2 < 0.4.0",
-                "cssstyle": "^1.0.0",
-                "data-urls": "^1.0.0",
-                "domexception": "^1.0.1",
-                "escodegen": "^1.9.1",
-                "html-encoding-sniffer": "^1.0.2",
-                "left-pad": "^1.3.0",
-                "nwsapi": "^2.0.7",
+                "abab": "2.0.0",
+                "acorn": "5.7.3",
+                "acorn-globals": "4.3.0",
+                "array-equal": "1.0.0",
+                "cssom": "0.3.6",
+                "cssstyle": "1.2.1",
+                "data-urls": "1.1.0",
+                "domexception": "1.0.1",
+                "escodegen": "1.11.1",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.3.0",
+                "nwsapi": "2.1.1",
                 "parse5": "4.0.0",
-                "pn": "^1.1.0",
-                "request": "^2.87.0",
-                "request-promise-native": "^1.0.5",
-                "sax": "^1.2.4",
-                "symbol-tree": "^3.2.2",
-                "tough-cookie": "^2.3.4",
-                "w3c-hr-time": "^1.0.1",
-                "webidl-conversions": "^4.0.2",
-                "whatwg-encoding": "^1.0.3",
-                "whatwg-mimetype": "^2.1.0",
-                "whatwg-url": "^6.4.1",
-                "ws": "^5.2.0",
-                "xml-name-validator": "^3.0.0"
+                "pn": "1.1.0",
+                "request": "2.88.0",
+                "request-promise-native": "1.0.7",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.5.0",
+                "w3c-hr-time": "1.0.1",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.5",
+                "whatwg-mimetype": "2.3.0",
+                "whatwg-url": "6.5.0",
+                "ws": "5.2.2",
+                "xml-name-validator": "3.0.0"
             }
         },
         "jsesc": {
@@ -2954,7 +2954,7 @@
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
             "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
             "requires": {
-                "minimist": "^1.2.0"
+                "minimist": "1.2.0"
             },
             "dependencies": {
                 "minimist": {
@@ -2990,7 +2990,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
             "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
             "requires": {
-                "invert-kv": "^2.0.0"
+                "invert-kv": "2.0.0"
             }
         },
         "left-pad": {
@@ -3008,8 +3008,8 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
             }
         },
         "load-json-file": {
@@ -3017,10 +3017,10 @@
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
             "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0",
-                "strip-bom": "^3.0.0"
+                "graceful-fs": "4.1.15",
+                "parse-json": "4.0.0",
+                "pify": "3.0.0",
+                "strip-bom": "3.0.0"
             }
         },
         "locate-path": {
@@ -3028,8 +3028,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
             "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
             "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "3.0.0",
+                "path-exists": "3.0.0"
             }
         },
         "lodash": {
@@ -3047,7 +3047,7 @@
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
+                "js-tokens": "3.0.2"
             }
         },
         "lru-cache": {
@@ -3056,8 +3056,8 @@
             "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
             "dev": true,
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
             }
         },
         "make-dir": {
@@ -3065,7 +3065,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
             }
         },
         "makeerror": {
@@ -3073,7 +3073,7 @@
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
             "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
             "requires": {
-                "tmpl": "1.0.x"
+                "tmpl": "1.0.4"
             }
         },
         "map-age-cleaner": {
@@ -3081,7 +3081,7 @@
             "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
             "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
             "requires": {
-                "p-defer": "^1.0.0"
+                "p-defer": "1.0.0"
             }
         },
         "map-cache": {
@@ -3094,7 +3094,7 @@
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
         },
         "media-typer": {
@@ -3107,9 +3107,9 @@
             "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
             "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
             "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
+                "map-age-cleaner": "0.1.3",
+                "mimic-fn": "2.0.0",
+                "p-is-promise": "2.0.0"
             },
             "dependencies": {
                 "mimic-fn": {
@@ -3129,7 +3129,7 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "methods": {
@@ -3142,19 +3142,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.13",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "mime": {
@@ -3172,7 +3172,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
             "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
             "requires": {
-                "mime-db": "~1.38.0"
+                "mime-db": "1.38.0"
             }
         },
         "mimic-fn": {
@@ -3186,7 +3186,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -3199,8 +3199,8 @@
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -3208,7 +3208,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -3237,17 +3237,17 @@
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "natural-compare": {
@@ -3285,11 +3285,11 @@
             "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
             "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
             "requires": {
-                "growly": "^1.3.0",
-                "is-wsl": "^1.1.0",
-                "semver": "^5.5.0",
-                "shellwords": "^0.1.1",
-                "which": "^1.3.0"
+                "growly": "1.3.0",
+                "is-wsl": "1.1.0",
+                "semver": "5.6.0",
+                "shellwords": "0.1.1",
+                "which": "1.3.1"
             }
         },
         "normalize-package-data": {
@@ -3297,10 +3297,10 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.7.1",
+                "resolve": "1.10.0",
+                "semver": "5.6.0",
+                "validate-npm-package-license": "3.0.4"
             }
         },
         "normalize-path": {
@@ -3308,7 +3308,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "npm-run-path": {
@@ -3316,7 +3316,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "number-is-nan": {
@@ -3345,9 +3345,9 @@
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -3355,7 +3355,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "kind-of": {
@@ -3363,7 +3363,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -3378,7 +3378,7 @@
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             }
         },
         "object.getownpropertydescriptors": {
@@ -3386,8 +3386,8 @@
             "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.1"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.13.0"
             }
         },
         "object.pick": {
@@ -3395,7 +3395,7 @@
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "on-finished": {
@@ -3411,7 +3411,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "onetime": {
@@ -3420,7 +3420,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "opn": {
@@ -3428,7 +3428,7 @@
             "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
             "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
             "requires": {
-                "is-wsl": "^1.1.0"
+                "is-wsl": "1.1.0"
             }
         },
         "optimist": {
@@ -3436,8 +3436,8 @@
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
             },
             "dependencies": {
                 "wordwrap": {
@@ -3452,12 +3452,12 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
             }
         },
         "os-locale": {
@@ -3465,9 +3465,9 @@
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
             "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
             "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
+                "execa": "1.0.0",
+                "lcid": "2.0.0",
+                "mem": "4.2.0"
             }
         },
         "os-tmpdir": {
@@ -3486,7 +3486,7 @@
             "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
             "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
             "requires": {
-                "p-reduce": "^1.0.0"
+                "p-reduce": "1.0.0"
             }
         },
         "p-finally": {
@@ -3504,7 +3504,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
             "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
             "requires": {
-                "p-try": "^2.0.0"
+                "p-try": "2.1.0"
             }
         },
         "p-locate": {
@@ -3512,7 +3512,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
             "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "requires": {
-                "p-limit": "^2.0.0"
+                "p-limit": "2.2.0"
             }
         },
         "p-reduce": {
@@ -3530,8 +3530,8 @@
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
+                "error-ex": "1.3.2",
+                "json-parse-better-errors": "1.0.2"
             }
         },
         "parse5": {
@@ -3554,8 +3554,8 @@
             "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
             "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
             "requires": {
-                "process": "^0.11.1",
-                "util": "^0.10.3"
+                "process": "0.11.10",
+                "util": "0.10.4"
             }
         },
         "path-exists": {
@@ -3594,7 +3594,7 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
             }
         },
         "performance-now": {
@@ -3612,7 +3612,7 @@
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
             "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
             "requires": {
-                "node-modules-regexp": "^1.0.0"
+                "node-modules-regexp": "1.0.0"
             }
         },
         "pkg-dir": {
@@ -3620,7 +3620,7 @@
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
             "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
             "requires": {
-                "find-up": "^3.0.0"
+                "find-up": "3.0.0"
             }
         },
         "pluralize": {
@@ -3639,9 +3639,9 @@
             "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
             "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
             "requires": {
-                "async": "^1.5.2",
-                "debug": "^2.2.0",
-                "mkdirp": "0.5.x"
+                "async": "1.5.2",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.1"
             }
         },
         "posix-character-classes": {
@@ -3659,10 +3659,10 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
             "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
             "requires": {
-                "@jest/types": "^24.5.0",
-                "ansi-regex": "^4.0.0",
-                "ansi-styles": "^3.2.0",
-                "react-is": "^16.8.4"
+                "@jest/types": "24.5.0",
+                "ansi-regex": "4.1.0",
+                "ansi-styles": "3.2.1",
+                "react-is": "16.8.4"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -3675,7 +3675,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.3"
                     }
                 }
             }
@@ -3701,8 +3701,8 @@
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
             "integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
             "requires": {
-                "kleur": "^3.0.2",
-                "sisteransi": "^1.0.0"
+                "kleur": "3.0.2",
+                "sisteransi": "1.0.0"
             }
         },
         "proxy-addr": {
@@ -3710,7 +3710,7 @@
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
             "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
             "requires": {
-                "forwarded": "~0.1.2",
+                "forwarded": "0.1.2",
                 "ipaddr.js": "1.8.0"
             }
         },
@@ -3730,8 +3730,8 @@
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
             }
         },
         "punycode": {
@@ -3770,9 +3770,9 @@
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "requires": {
-                "load-json-file": "^4.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^3.0.0"
+                "load-json-file": "4.0.0",
+                "normalize-package-data": "2.5.0",
+                "path-type": "3.0.0"
             }
         },
         "read-pkg-up": {
@@ -3780,8 +3780,8 @@
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
             "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
             "requires": {
-                "find-up": "^3.0.0",
-                "read-pkg": "^3.0.0"
+                "find-up": "3.0.0",
+                "read-pkg": "3.0.0"
             }
         },
         "readable-stream": {
@@ -3789,13 +3789,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "realpath-native": {
@@ -3803,7 +3803,7 @@
             "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
             "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
             "requires": {
-                "util.promisify": "^1.0.0"
+                "util.promisify": "1.0.0"
             }
         },
         "regex-not": {
@@ -3811,8 +3811,8 @@
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "regexpp": {
@@ -3841,26 +3841,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.8.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.7",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.3",
+                "har-validator": "5.1.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.22",
+                "oauth-sign": "0.9.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.4.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             },
             "dependencies": {
                 "punycode": {
@@ -3873,8 +3873,8 @@
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
+                        "psl": "1.1.31",
+                        "punycode": "1.4.1"
                     }
                 }
             }
@@ -3884,7 +3884,7 @@
             "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
             "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
             "requires": {
-                "lodash": "^4.17.11"
+                "lodash": "4.17.11"
             }
         },
         "request-promise-native": {
@@ -3893,8 +3893,8 @@
             "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
             "requires": {
                 "request-promise-core": "1.1.2",
-                "stealthy-require": "^1.1.1",
-                "tough-cookie": "^2.3.3"
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.5.0"
             }
         },
         "require-directory": {
@@ -3913,8 +3913,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "^0.1.0",
-                "resolve-from": "^1.0.0"
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
             }
         },
         "resolve": {
@@ -3922,7 +3922,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
             "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
             "requires": {
-                "path-parse": "^1.0.6"
+                "path-parse": "1.0.6"
             }
         },
         "resolve-cwd": {
@@ -3930,7 +3930,7 @@
             "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "3.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -3957,8 +3957,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
             }
         },
         "ret": {
@@ -3971,7 +3971,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
             "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "requires": {
-                "glob": "^7.1.3"
+                "glob": "7.1.3"
             }
         },
         "rsvp": {
@@ -3985,7 +3985,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "^2.1.0"
+                "is-promise": "2.1.0"
             }
         },
         "rx-lite": {
@@ -4000,7 +4000,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "*"
+                "rx-lite": "4.0.8"
             }
         },
         "safe-buffer": {
@@ -4013,7 +4013,7 @@
             "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "safer-buffer": {
@@ -4026,15 +4026,15 @@
             "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
             "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
             "requires": {
-                "@cnakazawa/watch": "^1.0.3",
-                "anymatch": "^2.0.0",
-                "capture-exit": "^2.0.0",
-                "exec-sh": "^0.3.2",
-                "execa": "^1.0.0",
-                "fb-watchman": "^2.0.0",
-                "micromatch": "^3.1.4",
-                "minimist": "^1.1.1",
-                "walker": "~1.0.5"
+                "@cnakazawa/watch": "1.0.3",
+                "anymatch": "2.0.0",
+                "capture-exit": "2.0.0",
+                "exec-sh": "0.3.2",
+                "execa": "1.0.0",
+                "fb-watchman": "2.0.0",
+                "micromatch": "3.1.10",
+                "minimist": "1.2.0",
+                "walker": "1.0.7"
             },
             "dependencies": {
                 "minimist": {
@@ -4060,18 +4060,18 @@
             "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
             "requires": {
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "~1.6.2",
+                "http-errors": "1.6.3",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "~2.3.0",
-                "range-parser": "~1.2.0",
-                "statuses": "~1.4.0"
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.4.0"
             }
         },
         "serve-static": {
@@ -4079,9 +4079,9 @@
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "requires": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.2",
                 "send": "0.16.2"
             }
         },
@@ -4095,10 +4095,10 @@
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4106,7 +4106,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -4121,7 +4121,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -4155,7 +4155,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0"
+                "is-fullwidth-code-point": "2.0.0"
             }
         },
         "snapdragon": {
@@ -4163,14 +4163,14 @@
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -4178,7 +4178,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -4186,7 +4186,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "source-map": {
@@ -4201,9 +4201,9 @@
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -4211,7 +4211,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4219,7 +4219,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -4227,7 +4227,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -4235,9 +4235,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -4247,7 +4247,7 @@
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -4255,7 +4255,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -4270,11 +4270,11 @@
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-support": {
@@ -4282,8 +4282,8 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
             "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.1.1",
+                "source-map": "0.6.1"
             }
         },
         "source-map-url": {
@@ -4296,8 +4296,8 @@
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
             "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.3"
             }
         },
         "spdx-exceptions": {
@@ -4310,8 +4310,8 @@
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-exceptions": "2.2.0",
+                "spdx-license-ids": "3.0.3"
             }
         },
         "spdx-license-ids": {
@@ -4324,7 +4324,7 @@
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             }
         },
         "sprintf-js": {
@@ -4337,15 +4337,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.4",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.2",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "stack-utils": {
@@ -4358,8 +4358,8 @@
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -4367,7 +4367,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -4387,8 +4387,8 @@
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
             "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
             "requires": {
-                "astral-regex": "^1.0.0",
-                "strip-ansi": "^4.0.0"
+                "astral-regex": "1.0.0",
+                "strip-ansi": "4.0.0"
             }
         },
         "string-width": {
@@ -4396,8 +4396,8 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
             }
         },
         "string_decoder": {
@@ -4405,7 +4405,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "strip-ansi": {
@@ -4413,7 +4413,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -4456,12 +4456,12 @@
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "dev": true,
             "requires": {
-                "ajv": "^5.2.3",
-                "ajv-keywords": "^2.1.0",
-                "chalk": "^2.1.0",
-                "lodash": "^4.17.4",
+                "ajv": "5.5.2",
+                "ajv-keywords": "2.1.1",
+                "chalk": "2.4.2",
+                "lodash": "4.17.11",
                 "slice-ansi": "1.0.0",
-                "string-width": "^2.1.1"
+                "string-width": "2.1.1"
             }
         },
         "test-exclude": {
@@ -4469,10 +4469,10 @@
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
             "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
             "requires": {
-                "arrify": "^1.0.1",
-                "minimatch": "^3.0.4",
-                "read-pkg-up": "^4.0.0",
-                "require-main-filename": "^1.0.1"
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4",
+                "read-pkg-up": "4.0.0",
+                "require-main-filename": "1.0.1"
             }
         },
         "text-table": {
@@ -4498,7 +4498,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "tmpl": {
@@ -4516,7 +4516,7 @@
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -4524,7 +4524,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -4534,10 +4534,10 @@
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "to-regex-range": {
@@ -4545,8 +4545,8 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             }
         },
         "tough-cookie": {
@@ -4554,8 +4554,8 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
+                "psl": "1.1.31",
+                "punycode": "2.1.1"
             }
         },
         "tr46": {
@@ -4563,7 +4563,7 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
             "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "trim-right": {
@@ -4576,7 +4576,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -4589,7 +4589,7 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "1.1.2"
             }
         },
         "type-is": {
@@ -4598,7 +4598,7 @@
             "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "~2.1.18"
+                "mime-types": "2.1.22"
             }
         },
         "typedarray": {
@@ -4613,8 +4613,8 @@
             "integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
             "optional": true,
             "requires": {
-                "commander": "~2.19.0",
-                "source-map": "~0.6.1"
+                "commander": "2.19.0",
+                "source-map": "0.6.1"
             }
         },
         "union-value": {
@@ -4622,10 +4622,10 @@
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4633,7 +4633,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "set-value": {
@@ -4641,10 +4641,10 @@
                     "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
                     }
                 }
             }
@@ -4659,8 +4659,8 @@
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -4668,9 +4668,9 @@
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -4695,7 +4695,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "urix": {
@@ -4726,8 +4726,8 @@
             "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "requires": {
-                "define-properties": "^1.1.2",
-                "object.getownpropertydescriptors": "^2.0.3"
+                "define-properties": "1.1.3",
+                "object.getownpropertydescriptors": "2.0.3"
             }
         },
         "utils-merge": {
@@ -4745,8 +4745,8 @@
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
+                "spdx-correct": "3.1.0",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "vary": {
@@ -4759,9 +4759,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "w3c-hr-time": {
@@ -4769,7 +4769,7 @@
             "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
             "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
             "requires": {
-                "browser-process-hrtime": "^0.1.2"
+                "browser-process-hrtime": "0.1.3"
             }
         },
         "walker": {
@@ -4777,7 +4777,7 @@
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
             "requires": {
-                "makeerror": "1.0.x"
+                "makeerror": "1.0.11"
             }
         },
         "webidl-conversions": {
@@ -4798,7 +4798,7 @@
                     "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
                     "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "safer-buffer": "2.1.2"
                     }
                 }
             }
@@ -4813,9 +4813,9 @@
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
             "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
             "requires": {
-                "lodash.sortby": "^4.7.0",
-                "tr46": "^1.0.1",
-                "webidl-conversions": "^4.0.2"
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
             }
         },
         "which": {
@@ -4823,7 +4823,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -4841,8 +4841,8 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -4850,7 +4850,7 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "string-width": {
@@ -4858,9 +4858,9 @@
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "strip-ansi": {
@@ -4868,7 +4868,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 }
             }
@@ -4884,7 +4884,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "^0.5.1"
+                "mkdirp": "0.5.1"
             }
         },
         "write-file-atomic": {
@@ -4892,9 +4892,9 @@
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
             "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
+                "graceful-fs": "4.1.15",
+                "imurmurhash": "0.1.4",
+                "signal-exit": "3.0.2"
             }
         },
         "ws": {
@@ -4902,7 +4902,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
             "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
             "requires": {
-                "async-limiter": "~1.0.0"
+                "async-limiter": "1.0.0"
             }
         },
         "xml-name-validator": {
@@ -4926,18 +4926,18 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
             "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
             "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.2.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^3.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1 || ^4.0.0",
-                "yargs-parser": "^11.1.1"
+                "cliui": "4.1.0",
+                "decamelize": "1.2.0",
+                "find-up": "3.0.0",
+                "get-caller-file": "1.0.3",
+                "os-locale": "3.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "4.0.0",
+                "yargs-parser": "11.1.1"
             }
         },
         "yargs-parser": {
@@ -4945,8 +4945,8 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
             "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
             "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
+                "camelcase": "5.2.0",
+                "decamelize": "1.2.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/plugin-express",
-    "version": "1.2.6",
+    "version": "1.3.6",
     "description": "A Skeletor plugin to run a local Express server.",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Prior to this PR, a check was being run for `entryPoints` in the plugin's config. Now this is optional, which allows you to define your static route (typically for Pattern Lab) manually through the `middleware` config option. This gives greater control of middleware loading order, per @heaper 's proposal: https://github.com/deg-skeletor/skeletor-plugin-express/issues/14